### PR TITLE
Display package name when failing to parse a version

### DIFF
--- a/src/Snitch/Analysis/Models/Package.cs
+++ b/src/Snitch/Analysis/Models/Package.cs
@@ -16,13 +16,13 @@ namespace Snitch.Analysis
             Version = ParseSemanticVersion(version ?? throw new ArgumentNullException(nameof(version)));
         }
 
-        private static SemVersion ParseSemanticVersion(string version)
+        private SemVersion ParseSemanticVersion(string version)
         {
             if (!SemVersion.TryParse(version, out var semanticVersion))
             {
                 if (!System.Version.TryParse(version, out var notSemanticVersion))
                 {
-                    throw new ArgumentException($"Version '{version}' is not valid.", nameof(version));
+                    throw new ArgumentException($"Version '{version}' for package '{Name}' is not valid.", nameof(version));
                 }
 
                 semanticVersion = SemVersion.Parse(notSemanticVersion.ToString(3));


### PR DESCRIPTION
Before:

```
Analysing project MyProject...

Building MyProject (net471)...

Error: Version '3.0.*' is not valid. (Parameter 'version')
```

After:

```
Analysing project MyProject...

Building MyProject (net471)...

Error: Version '3.0.*' for package 'ConfigureAwaitChecker.Analyzer' is not valid. (Parameter 'version')
```