### PR TITLE
roslyn fixes

### DIFF
--- a/src/Snitch/Analysis/Models/Package.cs
+++ b/src/Snitch/Analysis/Models/Package.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Diagnostics;
-using Semver;
+using NuGet.Versioning;
 
 namespace Snitch.Analysis
 {
@@ -8,27 +8,22 @@ namespace Snitch.Analysis
     internal sealed class Package
     {
         public string Name { get; }
-        public SemVersion Version { get; }
+        public NuGetVersion Version { get; }
 
         public Package(string name, string version)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            Version = ParseSemanticVersion(version ?? throw new ArgumentNullException(nameof(version)));
-        }
+            Version = ParseSemanticVersion(version ?? throw new ArgumentNullException(nameof(version)), Name);
 
-        private SemVersion ParseSemanticVersion(string version)
-        {
-            if (!SemVersion.TryParse(version, out var semanticVersion))
+            static NuGetVersion ParseSemanticVersion(string version, string name)
             {
-                if (!System.Version.TryParse(version, out var notSemanticVersion))
+                if (!NuGetVersion.TryParse(version, out var semanticVersion))
                 {
-                    throw new ArgumentException($"Version '{version}' for package '{Name}' is not valid.", nameof(version));
+                    throw new ArgumentException($"Version '{version}' for package '{name}' is not valid.", nameof(version));
                 }
 
-                semanticVersion = SemVersion.Parse(notSemanticVersion.ToString(3));
+                return semanticVersion;
             }
-
-            return semanticVersion;
         }
     }
 }

--- a/src/Snitch/Analysis/Models/PackageToRemove.cs
+++ b/src/Snitch/Analysis/Models/PackageToRemove.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 
+using NuGet.Versioning;
+
 namespace Snitch.Analysis
 {
     [DebuggerDisplay("{PackageDescription(),nq}")]
@@ -10,8 +12,8 @@ namespace Snitch.Analysis
         public Package Package { get; }
         public ProjectPackage Original { get; }
 
-        public bool CanBeRemoved => Package.Version == Original.Package.Version;
-        public bool VersionMismatch => Package.Version != Original.Package.Version;
+        public bool CanBeRemoved => new VersionComparer().Equals(Package.Version, Original.Package.Version);
+        public bool VersionMismatch => !new VersionComparer().Equals(Package.Version, Original.Package.Version);
 
         public PackageToRemove(Project project, Package package, ProjectPackage original)
         {

--- a/src/Snitch/Analysis/ProjectBuilder.cs
+++ b/src/Snitch/Analysis/ProjectBuilder.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
 using Buildalyzer;
+
 using Snitch.Analysis.Utilities;
 
 namespace Snitch.Analysis
@@ -103,8 +105,27 @@ namespace Snitch.Analysis
                     }
                 }
 
-                var analyzedProjectReference = Build(manager, projectReferencePath, project.TargetFramework, skip, built);
+                if (!projectReferencePath.EndsWith("csproj", StringComparison.OrdinalIgnoreCase))
+                {
+                    _console.Write("   -> Skipping Non C# Project ");
+                    _console.ForegroundColor = ConsoleColor.Cyan;
+                    _console.Write(project.Name);
+                    _console.ResetColor();
+                    if (!string.IsNullOrWhiteSpace(tfm))
+                    {
+                        _console.ForegroundColor = ConsoleColor.DarkGray;
+                        _console.Write(" (");
+                        _console.Write(tfm);
+                        _console.Write(")");
+                        _console.ResetColor();
+                    }
 
+                    _console.WriteLine();
+
+                    continue;
+                }
+
+                var analyzedProjectReference = Build(manager, projectReferencePath, project.TargetFramework, skip, built);
                 project.ProjectReferences.Add(analyzedProjectReference);
             }
 

--- a/src/Snitch/Analysis/ProjectReporter.cs
+++ b/src/Snitch/Analysis/ProjectReporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using NuGet.Versioning;
 
 namespace Snitch.Analysis
 {
@@ -89,7 +90,7 @@ namespace Snitch.Analysis
             _console.ForegroundColor = ConsoleColor.Gray;
             _console.WriteLine(item.Package.Version.ToString());
 
-            if (item.Package.Version > item.Original.Package.Version)
+            if (new VersionComparer().Compare(item.Package.Version, item.Original.Package.Version) > 0)
             {
                 _console.ForegroundColor = ConsoleColor.DarkGray;
                 _console.Write("     Updated from ");

--- a/src/Snitch/Snitch.csproj
+++ b/src/Snitch/Snitch.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -29,7 +29,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks" Version="5.3.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.3.1" />
-    <PackageReference Include="Semver" Version="2.0.4" />
+    <PackageReference Include="NuGet.Versioning" Version="5.3.1" />
     <PackageReference Include="Spectre.Cli" Version="0.28.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Two changes I needed to make to run this tool over github.com/dotnet/roslyn

1. Use the nuget to parse the version string and do comparisions
2. Skip non-C# projects
