### PR TITLE
Fix `FormatException: Input string was not in a correct format`

### DIFF
--- a/src/Snitch/Analysis/ProjectBuilder.cs
+++ b/src/Snitch/Analysis/ProjectBuilder.cs
@@ -121,18 +121,11 @@ namespace Snitch.Analysis
                     }
                 }
 
-                if (!projectReferencePath.EndsWith("csproj", StringComparison.OrdinalIgnoreCase))
+                if (!projectReferencePath.EndsWith("csproj", StringComparison.OrdinalIgnoreCase) && !projectReferencePath.EndsWith("fsproj", StringComparison.OrdinalIgnoreCase))
                 {
-                    _console.MarkupLine("Skipping Non C# Project [aqua]{project.Name}[/]");
-
-                    if (!string.IsNullOrWhiteSpace(tfm))
-                    {
-                        _console.MarkupLine("Skipping Non C# Project [aqua]{project.Name}[/] [grey] ({tfm})[/]");
-                    }
-                    else
-                    {
-                        _console.MarkupLine("Skipping Non C# Project [aqua]{project.Name}[/]");
-                    }
+                    _console.MarkupLine(string.IsNullOrWhiteSpace(tfm)
+                        ? $"Skipping Non .NET Project [aqua]{project.Name}[/]"
+                        : $"Skipping Non .NET Project [aqua]{project.Name}[/] [grey] ({tfm})[/]");
 
                     _console.WriteLine();
 


### PR DESCRIPTION
Also no reason to ignore .fsproj as they also have ProjectReference and PackageReference and follow the csproj format.

Trying to scan a solution with a mix of csproj and fsproj. You would land into condition and trigger an error due to the `{project.Name}` forced a incorrect string format.