### PR TITLE
Support *.vbproj project files

### DIFF
--- a/src/Snitch/Analysis/ProjectBuilder.cs
+++ b/src/Snitch/Analysis/ProjectBuilder.cs
@@ -123,7 +123,7 @@ namespace Snitch.Analysis
                     }
                 }
 
-                if (!projectReferencePath.EndsWith("csproj", StringComparison.OrdinalIgnoreCase) && !projectReferencePath.EndsWith("fsproj", StringComparison.OrdinalIgnoreCase))
+                if (!projectReferencePath.EndsWith("vbproj", StringComparison.OrdinalIgnoreCase) && !projectReferencePath.EndsWith("csproj", StringComparison.OrdinalIgnoreCase) && !projectReferencePath.EndsWith("fsproj", StringComparison.OrdinalIgnoreCase))
                 {
                     _console.MarkupLine(string.IsNullOrWhiteSpace(tfm)
                         ? $"Skipping Non .NET Project [aqua]{project.Name}[/]"


### PR DESCRIPTION
Include *.vbproj files in the list of supported project files to be able to analyse mixed or vb.net only solutions.